### PR TITLE
Add build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,85 @@
+name: Build app for all platforms
+
+on:
+  workflow_dispatch:
+
+jobs:
+  pre-run:
+    name: Create draft release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Find release version 
+        id: release-version
+        run: |
+          VERSION_LINE=$(grep '^version:' pubspec.yaml)
+          VERSION_WITH_BUILD_NUMBER=$(echo "$VERSION_LINE" | sed -E 's/version: *([^ ]*)/\1/')
+          VERSION=${VERSION_WITH_BUILD_NUMBER%+*}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+      - name: Create the new tag
+        # Taken from https://stackoverflow.com/questions/60963759/use-github-actions-to-create-a-tag-but-not-a-release/64479344#64479344
+        uses: actions/github-script@v9
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/${{ steps.release-version.outputs.version }}',
+              sha: context.sha
+            })
+    outputs:
+      release-version: ${{ steps.release-version.outputs.version }}
+
+  release-app:
+    name: Release app as ${{ matrix.build-type }} (${{ matrix.platform }}) on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    needs: pre-run
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: android
+            build-type: apk
+          - os: windows-latest
+            platform: windows
+            build-type: windows
+          - os: ubuntu-latest
+            platform: linux
+            build-type: debian
+          - os: macos-latest
+            platform: macos
+            build-type: macos
+          - os: macos-latest
+            platform: ios
+            build-type: ipa
+    steps:
+      - uses: actions/checkout@v6
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: beta
+      - run: flutter --version
+      - uses: actions/setup-java@v4
+        if: matrix.platform == 'android'
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Install Linux Dependencies
+        # Install libayatana-appindicator3-dev for app flutter deps, see https://github.com/leanflutter/tray_manager#linux-requirements
+        # Install libunwind-dev, see https://github.com/actions/runner-images/issues/6399#issuecomment-1285011525
+        # Install other base packages, see https://medium.com/@fluttergems/packaging-and-distributing-flutter-desktop-apps-the-missing-guide-part-3-linux-24ef8d30a5b4#e8f7
+        if: matrix.platform == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libayatana-appindicator3-dev
+          sudo apt-get install -y libunwind-dev
+          sudo apt-get install -y clang cmake git ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev 
+      - name: Build
+        uses: oberhauser-dev/flutter-release-action@v0
+        with:
+          dry-run: true
+          app-version: v${{ needs.pre-run.outputs.release-version }}
+          tag: ${{ needs.pre-run.outputs.release-version }}
+          build-type: ${{ matrix.build-type }}
+          token: ${{ github.token }}


### PR DESCRIPTION
Hello,

This PR adds a build workflow that is to be triggered manually in the Actions tab. 
Here is a summary of what it does:
- Takes the app version number defined in `pubspec.yaml`
- Creates a Github tag based on the version number
- For each platform:
  - Install Flutter and platform-specific dependencies
  - Build the app
  - Upload built artifiacts to a released (named after the version number)
- Publish the release. Note that the PR currently uses [`dry-run: true` parameter](https://github.com/oleole39/netshare/blob/24abc2ab37e6f678ca3bc055f10f41eb971ec25f/.github/workflows/build.yml#L81) for test purposes, and that it will have to be toggled to `false` so that the release actually gets created.  

A (not dry-) run log can be found there: https://github.com/oleole39/netshare/actions/runs/26201793948
Together with its corresponding published release: https://github.com/oleole39/netshare/releases/tag/2.2.0
 
The workflow seems to work fine, but there are issues in the build process. I tried to follow instructions in the repo's README, but those might be outdated. Here are platform-related comments (more info can be found in the log):
- Android: build fails, likely due to missing keyfile for signed APK build process. Introducing a build for an unsigned APK could be an idea.
- Windows: build succeeds. Untested.
- Linux: build succeeds. The .deb file can be installed. The installed app can be launched, however it just opens a black window with nothing in it  (tested on Linux Mint 22.2).
- MacOS: build fails, for some reason.
- iOS: build fails (although the Github runner says it succeeded) - no file is built and therefore no artifiact uploaded.

PS: A tricky point with Github FYI just in case - workflows appear in the Actions tab only when added to the master branch (or at least a first one, later versions can be run from other branches provided they have the same name than the one in the master branch).